### PR TITLE
Fix login credential handling

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -21,7 +21,9 @@ export class AuthService {
 
     //TLDR; 입력받은 비밀번호"와 "저장된 해시 비밀번호" 비교검증
     const isPasswordValid = await bcrypt.compare(password, user.password);
-    if (!isPasswordValid) return null;
+    if (!isPasswordValid) {
+      throw new HttpException('Invalid credentials', HttpStatus.UNAUTHORIZED);
+    }
 
     const payload = { sub: user.id, email: user.email };
     const accessToken = this.jwtService.sign(payload);


### PR DESCRIPTION
## Summary
- raise `Unauthorized` when password mismatch during login

## Testing
- `npm test` *(fails: jest not found)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb3833f1c8320a49b82b061af1628