### PR TITLE
Implement post CRUD endpoints

### DIFF
--- a/src/post/dto/update-post.dto.ts
+++ b/src/post/dto/update-post.dto.ts
@@ -1,23 +1,26 @@
 import {
+  IsOptional,
   IsString,
   IsEnum,
   IsBoolean,
-  IsOptional,
   IsObject,
   IsArray,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { PostType } from '@prisma/client';
 
-export class CreatePostDto {
+export class UpdatePostDto {
+  @IsOptional()
   @IsEnum(PostType)
-  type: PostType;
+  type?: PostType;
 
+  @IsOptional()
   @IsString()
-  title: string;
+  title?: string;
 
+  @IsOptional()
   @IsObject()
-  content: Record<string, any>; // ProseMirror JSON을 stringified 상태로 받는다고 가정
+  content?: Record<string, any>;
 
   @IsOptional()
   @IsBoolean()
@@ -27,5 +30,5 @@ export class CreatePostDto {
   @IsArray()
   @IsString({ each: true })
   @Type(() => String)
-  tagNames?: string[]; // 태그 이름 배열로 전달
+  tagNames?: string[];
 }

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -7,9 +7,13 @@ import {
   Req,
   Get,
   Query,
+  Param,
+  Patch,
+  Delete,
 } from '@nestjs/common';
 import { PostService } from './post.service';
 import { CreatePostDto } from './dto/create-post.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 import { RequestWithUser } from 'src/common/types/request-with-user';
 import { GetPostsDto } from './dto/get-posts.dto';
@@ -27,5 +31,27 @@ export class PostController {
   @Get()
   async getPosts(@Query() query: GetPostsDto) {
     return this.postService.getPosts(query);
+  }
+
+  @Get(':id')
+  async getPost(@Param('id') id: string) {
+    return this.postService.getPostById(id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch(':id')
+  async updatePost(
+    @Param('id') id: string,
+    @Body() dto: UpdatePostDto,
+    @Req() req: RequestWithUser,
+  ) {
+    return this.postService.updatePost(id, dto, req.user.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id')
+  async deletePost(@Param('id') id: string, @Req() req: RequestWithUser) {
+    await this.postService.deletePost(id, req.user.id);
+    return {};
   }
 }

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostService } from './post.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { HttpException } from '@nestjs/common';
+import { UpdatePostDto } from './dto/update-post.dto';
+
+const mockPrismaService = {
+  post: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+};
+
+describe('PostService 서비스', () => {
+  let service: PostService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PostService, { provide: PrismaService, useValue: mockPrismaService }],
+    }).compile();
+
+    service = module.get<PostService>(PostService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('작성자가 게시글을 업데이트할 수 있다', async () => {
+    mockPrismaService.post.findUnique.mockResolvedValue({ id: '1', authorId: 'user1' });
+    mockPrismaService.post.update.mockResolvedValue({ id: '1', title: 'new title' });
+
+    const dto: UpdatePostDto = { title: 'new title' };
+    const result = await service.updatePost('1', dto, 'user1');
+
+    expect(mockPrismaService.post.update).toHaveBeenCalled();
+    expect(result.title).toBe('new title');
+  });
+
+  it('존재하지 않는 게시글 업데이트 시 예외 발생', async () => {
+    mockPrismaService.post.findUnique.mockResolvedValue(null);
+
+    await expect(service.updatePost('1', { title: 'x' }, 'user1')).rejects.toBeInstanceOf(HttpException);
+  });
+
+  it('작성자가 게시글을 삭제할 수 있다', async () => {
+    mockPrismaService.post.findUnique.mockResolvedValue({ id: '1', authorId: 'user1' });
+    mockPrismaService.post.delete.mockResolvedValue({});
+
+    await service.deletePost('1', 'user1');
+
+    expect(mockPrismaService.post.delete).toHaveBeenCalledWith({ where: { id: '1' } });
+  });
+
+  it('존재하지 않는 게시글 삭제 시 예외 발생', async () => {
+    mockPrismaService.post.findUnique.mockResolvedValue(null);
+
+    await expect(service.deletePost('1', 'user1')).rejects.toBeInstanceOf(HttpException);
+  });
+});

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { Injectable } from '@nestjs/common';
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { PostType } from '@prisma/client';
 import { GetPostsDto } from './dto/get-posts.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
 
 @Injectable()
 export class PostService {
@@ -106,5 +107,58 @@ export class PostService {
         nextCursor,
       },
     };
+  }
+
+  async getPostById(postId: string) {
+    return this.prisma.post.findUnique({
+      where: { id: postId },
+      include: {
+        tags: true,
+        author: {
+          select: {
+            id: true,
+            username: true,
+          },
+        },
+      },
+    });
+  }
+
+  async updatePost(postId: string, dto: UpdatePostDto, userId: string) {
+    const post = await this.prisma.post.findUnique({ where: { id: postId } });
+
+    if (!post || post.authorId !== userId) {
+      throw new HttpException('Post not found', HttpStatus.NOT_FOUND);
+    }
+
+    if (dto.type && !Object.values(PostType).includes(dto.type)) {
+      throw new Error('Invalid post type');
+    }
+
+    const { tagNames, ...rest } = dto;
+    const data: any = { ...rest };
+
+    if (tagNames) {
+      data.tags = {
+        set: [],
+        connectOrCreate: this.makeTags(tagNames),
+      };
+    }
+
+    return this.prisma.post.update({
+      where: { id: postId },
+      data,
+      include: { tags: true },
+    });
+  }
+
+  async deletePost(postId: string, userId: string) {
+    const post = await this.prisma.post.findUnique({ where: { id: postId } });
+
+    if (!post || post.authorId !== userId) {
+      throw new HttpException('Post not found', HttpStatus.NOT_FOUND);
+    }
+
+    await this.prisma.post.delete({ where: { id: postId } });
   }
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -4,7 +4,7 @@ import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
 
-describe('AppController (e2e)', () => {
+describe('AppController (e2e) 테스트', () => {
   let app: INestApplication<App>;
 
   beforeEach(async () => {
@@ -16,7 +16,7 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/ (GET)', () => {
+  it('루트 엔드포인트 (GET)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -4,7 +4,7 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
 
-describe('UserController (e2e)', () => {
+describe('UserController (e2e) 테스트', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
@@ -20,7 +20,7 @@ describe('UserController (e2e)', () => {
     await app.close();
   });
 
-  it('POST /user/signup', async () => {
+  it('POST /user/signup - 회원가입', async () => {
     const response = await request(app.getHttpServer())
       .post('/user/signup')
       .send({
@@ -34,7 +34,7 @@ describe('UserController (e2e)', () => {
     expect(response.body.email).toBe('testuser2@example.com');
   });
 
-  it('POST /user/login', async () => {
+  it('POST /user/login - 로그인', async () => {
     const response = await request(app.getHttpServer())
       .post('/user/login')
       .send({


### PR DESCRIPTION
## Summary
- enable fetching, updating and deleting posts
- validate update parameters with `UpdatePostDto`
- expose new routes in `PostController`
- 테스트 코드 설명을 한글로 변경

## Testing
- `npm test` *(fails: jest not found)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb5400758832087570bf286a78047