### PR TITLE
Add crew model and user roles

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,11 +12,17 @@ model User {
   email     String   @unique
   username  String
   password  String
+  role      UserRole @default(USER)
+  influencerLevel InfluencerLevel @default(NONE)
+  bio       String?
+  imageUrl  String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   deletedAt DateTime?
   //1:N
   posts     Post[]
+  crewsOwned  Crew[]     @relation("CrewOwner")
+  crewMembers CrewMember[]
 }
 
 model Post {
@@ -24,13 +30,16 @@ model Post {
   type       PostType
   title      String
   // ProseMirror content 저장을 위해 Json으로 지정
-  content    Json      
+  content    Json
   isDraft    Boolean   @default(false)
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
   // N:1
   author User @relation(fields: [authorId], references: [id], onDelete: Cascade)
   authorId   String
+  // Crew relation (optional)
+  crew     Crew?   @relation(fields: [crewId], references: [id])
+  crewId   String?
   // N:M
   tags       Tag[]     @relation("PostTags")
 
@@ -43,6 +52,48 @@ model Tag {
   createdAt DateTime @default(now())
   // M:N
   posts Post[]  @relation("PostTags")
+}
+
+model Crew {
+  id          String   @id @default(uuid())
+  name        String
+  description String?
+  coverImage  String?
+  links       Json?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  owner     User   @relation("CrewOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  ownerId   String
+  posts     Post[]
+  members   CrewMember[]
+
+  @@unique([name])
+}
+
+model CrewMember {
+  crew     Crew   @relation(fields: [crewId], references: [id], onDelete: Cascade)
+  crewId   String
+  user     User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId   String
+  joinedAt DateTime @default(now())
+
+  @@id([crewId, userId])
+}
+
+enum UserRole {
+  USER
+  PUBLISHER
+  INFLUENCER
+  BRAND
+  MASTER
+}
+
+enum InfluencerLevel {
+  NONE
+  BRONZE
+  SILVER
+  GOLD
 }
 
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { UserModule } from './user/user.module';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 import { PostModule } from './post/post.module';
+import { CrewModule } from './crew/crew.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { PostModule } from './post/post.module';
     AuthModule,
     UserModule,
     PostModule,
+    CrewModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/crew/crew.controller.ts
+++ b/src/crew/crew.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { RequestWithUser } from 'src/common/types/request-with-user';
+import { CreateCrewDto } from './dto/create-crew.dto';
+import { CrewService } from './crew.service';
+
+@Controller('crew')
+export class CrewController {
+  constructor(private readonly crewService: CrewService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  create(@Body() dto: CreateCrewDto, @Req() req: RequestWithUser) {
+    return this.crewService.create(dto, req.user.id);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.crewService.findOne(id);
+  }
+}

--- a/src/crew/crew.module.ts
+++ b/src/crew/crew.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CrewService } from './crew.service';
+import { CrewController } from './crew.controller';
+
+@Module({
+  controllers: [CrewController],
+  providers: [CrewService],
+})
+export class CrewModule {}

--- a/src/crew/crew.service.ts
+++ b/src/crew/crew.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateCrewDto } from './dto/create-crew.dto';
+
+@Injectable()
+export class CrewService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(dto: CreateCrewDto, ownerId: string) {
+    const { name, description, coverImage, links } = dto;
+    return this.prisma.crew.create({
+      data: {
+        name,
+        description,
+        coverImage,
+        links,
+        ownerId,
+      },
+    });
+  }
+
+  findOne(id: string) {
+    return this.prisma.crew.findUnique({
+      where: { id },
+      include: {
+        owner: {
+          select: { id: true, username: true },
+        },
+      },
+    });
+  }
+}

--- a/src/crew/dto/create-crew.dto.ts
+++ b/src/crew/dto/create-crew.dto.ts
@@ -1,0 +1,17 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class CreateCrewDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  coverImage?: string;
+
+  @IsOptional()
+  links?: Record<string, any>;
+}

--- a/src/post/dto/create-post.dto.ts
+++ b/src/post/dto/create-post.dto.ts
@@ -23,4 +23,8 @@ export class CreatePostDto {
 
   @IsOptional()
   tagNames?: string[]; // 태그 이름 배열로 전달
+
+  @IsOptional()
+  @IsString()
+  crewId?: string;
 }

--- a/src/post/dto/get-posts.dto.ts
+++ b/src/post/dto/get-posts.dto.ts
@@ -26,4 +26,8 @@ export class GetPostsDto {
   @IsString({ each: true })
   @Type(() => String)
   tags?: string[];
+
+  @IsOptional()
+  @IsString()
+  crewId?: string;
 }

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -20,7 +20,7 @@ export class PostService {
   }
 
   async createPost(dto: CreatePostDto, userId: string) {
-    const { title, content, isDraft, tagNames } = dto;
+    const { title, content, isDraft, tagNames, crewId } = dto;
 
     if (!Object.values(PostType).includes(dto.type)) {
       //알 수 없는 이유로 $Enum.PostType이 계속 일반 변수에도 할당되지 않으므로 타입 가드 추가
@@ -38,6 +38,7 @@ export class PostService {
         content,
         isDraft,
         authorId: userId,
+        ...(crewId && { crewId }),
         tags: {
           connectOrCreate: this.makeTags(tagNames),
         },
@@ -49,7 +50,7 @@ export class PostService {
   }
 
   async getPosts(dto: GetPostsDto) {
-    const { take = '10', cursor, tags } = dto;
+    const { take = '10', cursor, tags, crewId } = dto;
     const postType = dto.postType;
     const takeNum = parseInt(take, 10);
 
@@ -69,6 +70,10 @@ export class PostService {
           },
         },
       };
+    }
+
+    if (crewId) {
+      where.crewId = crewId;
     }
 
     const posts = await this.prisma.post.findMany({


### PR DESCRIPTION
## Summary
- add user role and influencer level enums
- add Crew and CrewMember models with Post relation
- allow posts to reference a crew
- expose crew create/get APIs via new module

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_683fddc8118483208b2818d40ced3557