### PR TITLE
feat: expand schema for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,22 @@
 - folks/front-end에서 진행 예정
   - PageTransition 시스템 연동 (프론트단)
   - 반응형 대응 및 Tailwind 기반 디자인 시스템
+## 🚧 남은 작업 (v2 Plan)
+
+- [ ] CREW 생성/수정/삭제 API 확장
+- [ ] CREW 전용 게시글/리뷰 등록 기능
+- [ ] CREW NOTICE 노출 및 외부 링크 지원
+- [ ] 오프라인 이벤트 스키마(Event) 추가
+- [ ] 이벤트 등록/조회 API 구현
+- [ ] 프로필에 CREW 활동 이력 노출
+- [ ] BRAND 게시물 상단 고정(BM 기능)
+- [ ] CREW 페이지 스폰서 영역 관리
+- [ ] Premium COLUMN 표시 구조 반영
+- [ ] Vitest 기반 단위 테스트 작성
+- [ ] Playwright E2E 테스트 작성
+- [ ] UX 개선 및 디자인 피드백 반영
+
+## 🔄 최근 업데이트
+
+- Event 모델과 후원 필드 등 v2 기능을 반영하여 Prisma 스키마를 수정했습니다.
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model User {
   followers       Follow[]        @relation("FollowingUser")
   following       Follow[]        @relation("FollowerUser")
   Comment         Comment[]
+  eventAttendances EventAttendee[]
 }
 
 model Post {
@@ -48,6 +49,8 @@ model Post {
   tags      Tag[]      @relation("PostTags")
   comments  Comment[]
   PostLike  PostLike[]
+  pinnedUntil DateTime?
+  isPremium  Boolean   @default(false)
 
   @@index([type, createdAt])
 }
@@ -66,6 +69,8 @@ model Crew {
   description String?
   coverImage  String?
   links       Json?
+  sponsorImage String?
+  sponsorUrl   String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
@@ -73,8 +78,34 @@ model Crew {
   ownerId String
   posts   Post[]
   members CrewMember[]
+  events  Event[]
 
   @@unique([name])
+}
+
+model Event {
+  id        String   @id @default(uuid())
+  crew      Crew     @relation(fields: [crewId], references: [id], onDelete: Cascade)
+  crewId    String
+  title     String
+  date      DateTime
+  location  String?
+  link      String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  attendees EventAttendee[]
+
+  @@index([crewId, date])
+}
+
+model EventAttendee {
+  event    Event   @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  eventId  String
+  user     User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId   String
+  joinedAt DateTime @default(now())
+
+  @@id([eventId, userId])
 }
 
 model CrewMember {


### PR DESCRIPTION
## Summary
- extend `prisma/schema.prisma` with event models and sponsor fields
- add pinned posts and premium columns
- document recent schema changes in README

## Testing
- `pnpm test`
- `npx prisma generate` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6853692ed6288320bf217e320cd14bd1