### PR TITLE
Implement Crew permissions

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,10 +77,27 @@ model Crew {
   owner   User         @relation("CrewOwner", fields: [ownerId], references: [id], onDelete: Cascade)
   ownerId String
   posts   Post[]
+  roles   CrewRole[]
   members CrewMember[]
   events  Event[]
 
   @@unique([name])
+}
+
+model CrewRole {
+  id     Int      @id @default(autoincrement())
+  name   String
+  crew   Crew     @relation(fields: [crewId], references: [id])
+  crewId String
+  permissions CrewPermission[]
+  members     CrewMember[]
+}
+
+model CrewPermission {
+  id     Int     @id @default(autoincrement())
+  action String
+  role   CrewRole @relation(fields: [roleId], references: [id])
+  roleId Int
 }
 
 model Event {
@@ -113,6 +130,8 @@ model CrewMember {
   crewId   String
   user     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId   String
+  role     CrewRole @relation(fields: [roleId], references: [id])
+  roleId   Int
   joinedAt DateTime @default(now())
 
   @@id([crewId, userId])

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { CrewModule } from './crew/crew.module';
 import { CommentModule } from './comment/comment.module';
 import { EventModule } from './event/event.module';
 import { CrewMemberModule } from './crew-member/crew-member.module';
+import { CrewPermissionModule } from './crew-permission/crew-permission.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { CrewMemberModule } from './crew-member/crew-member.module';
     PostModule,
     CrewModule,
     EventModule,
+    CrewPermissionModule,
     CrewMemberModule,
     CommentModule,
   ],

--- a/src/crew-member/crew-member.controller.ts
+++ b/src/crew-member/crew-member.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Param, Post, UseGuards, Req, Get } from '@nestjs/common';
+import { Controller, Param, Post, UseGuards, Req, Get, Body } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 import { RequestWithUser } from 'src/common/types/request-with-user';
 import { CrewMemberService } from './crew-member.service';
@@ -9,8 +9,12 @@ export class CrewMemberController {
 
   @UseGuards(JwtAuthGuard)
   @Post(':crewId/join')
-  join(@Param('crewId') crewId: string, @Req() req: RequestWithUser) {
-    return this.service.join(crewId, req.user.id);
+  join(
+    @Param('crewId') crewId: string,
+    @Req() req: RequestWithUser,
+    @Body('roleId') roleId: number,
+  ) {
+    return this.service.join(crewId, req.user.id, roleId);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/crew-member/crew-member.service.ts
+++ b/src/crew-member/crew-member.service.ts
@@ -5,9 +5,9 @@ import { PrismaService } from 'src/prisma/prisma.service';
 export class CrewMemberService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async join(crewId: string, userId: string) {
+  async join(crewId: string, userId: string, roleId: number) {
     return this.prisma.crewMember.create({
-      data: { crewId, userId },
+      data: { crewId, userId, roleId },
     });
   }
 

--- a/src/crew-permission/crew-permission.module.ts
+++ b/src/crew-permission/crew-permission.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CrewPermissionService } from './crew-permission.service';
+
+@Module({
+  providers: [CrewPermissionService],
+  exports: [CrewPermissionService],
+})
+export class CrewPermissionModule {}

--- a/src/crew-permission/crew-permission.service.ts
+++ b/src/crew-permission/crew-permission.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class CrewPermissionService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async hasPermission(
+    crewId: string,
+    userId: string,
+    action: string,
+  ): Promise<boolean> {
+    const permission = await this.prisma.crewPermission.findFirst({
+      where: {
+        action,
+        role: {
+          members: {
+            some: {
+              crewId,
+              userId,
+            },
+          },
+        },
+      },
+    });
+    return !!permission;
+  }
+}

--- a/src/prisma/crew-permission-action.ts
+++ b/src/prisma/crew-permission-action.ts
@@ -1,0 +1,8 @@
+export enum CrewPermissionAction {
+  CREATE_NOTICE = 'create_notice',
+  CREATE_EVENT = 'create_event',
+  EDIT_CREW_INTRO = 'edit_crew_intro',
+  DELETE_POST = 'delete_post',
+  PIN_TOPIC = 'pin_topic',
+  MANAGE_MEMBER = 'manage_member',
+}


### PR DESCRIPTION
## Summary
- add expandable crew permission system models
- expose crew permissions via new service and module
- allow setting role when joining crew
- add constants for crew permission actions

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b678944a48320a38e64446406866e