### PR TITLE
Add crew tab system

### DIFF
--- a/prisma/migrations/20250625000000_add_crew_tab/migration.sql
+++ b/prisma/migrations/20250625000000_add_crew_tab/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "CrewTabType" AS ENUM ('OVERVIEW','POSTS','NOTICE','EVENT','TOPIC');
+
+-- CreateTable
+CREATE TABLE "CrewTab" (
+    "id" TEXT NOT NULL,
+    "crewId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "type" "CrewTabType" NOT NULL,
+    "isVisible" BOOLEAN NOT NULL DEFAULT true,
+    "order" INTEGER NOT NULL,
+    "hashtag" TEXT,
+    CONSTRAINT "CrewTab_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CrewTab_crewId_order_idx" ON "CrewTab"("crewId", "order");
+
+-- AddForeignKey
+ALTER TABLE "CrewTab" ADD CONSTRAINT "CrewTab_crewId_fkey" FOREIGN KEY ("crewId") REFERENCES "Crew"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,6 +108,19 @@ model EventAttendee {
   @@id([eventId, userId])
 }
 
+model CrewTab {
+  id        String      @id @default(uuid())
+  crew      Crew        @relation(fields: [crewId], references: [id], onDelete: Cascade)
+  crewId    String
+  title     String
+  type      CrewTabType
+  isVisible Boolean     @default(true)
+  order     Int
+  hashtag   String?
+
+  @@index([crewId, order])
+}
+
 model CrewMember {
   crew     Crew     @relation(fields: [crewId], references: [id], onDelete: Cascade)
   crewId   String
@@ -176,4 +189,12 @@ enum PostType {
   CREW
   BRAND
   NOTICE
+}
+
+enum CrewTabType {
+  OVERVIEW
+  POSTS
+  NOTICE
+  EVENT
+  TOPIC
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { CrewModule } from './crew/crew.module';
 import { CommentModule } from './comment/comment.module';
 import { EventModule } from './event/event.module';
 import { CrewMemberModule } from './crew-member/crew-member.module';
+import { CrewTabModule } from './crew-tab/crew-tab.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { CrewMemberModule } from './crew-member/crew-member.module';
     EventModule,
     CrewMemberModule,
     CommentModule,
+    CrewTabModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/crew-tab/crew-tab.controller.ts
+++ b/src/crew-tab/crew-tab.controller.ts
@@ -1,0 +1,48 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { RequestWithUser } from 'src/common/types/request-with-user';
+import { CreateCrewTabDto } from './dto/create-crew-tab.dto';
+import { UpdateCrewTabDto } from './dto/update-crew-tab.dto';
+import { CrewTabService } from './crew-tab.service';
+
+@Controller('crew')
+export class CrewTabController {
+  constructor(private readonly service: CrewTabService) {}
+
+  @Get(':crewId/tabs')
+  list(@Param('crewId') crewId: string) {
+    return this.service.findCrewTabs(crewId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':crewId/tabs')
+  create(
+    @Param('crewId') crewId: string,
+    @Body() dto: CreateCrewTabDto,
+    @Req() _req: RequestWithUser,
+  ) {
+    return this.service.create(crewId, dto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('tabs/:id')
+  update(@Param('id') id: string, @Body() dto: UpdateCrewTabDto) {
+    return this.service.update(id, dto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete('tabs/:id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/src/crew-tab/crew-tab.module.ts
+++ b/src/crew-tab/crew-tab.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CrewTabService } from './crew-tab.service';
+import { CrewTabController } from './crew-tab.controller';
+
+@Module({
+  controllers: [CrewTabController],
+  providers: [CrewTabService],
+})
+export class CrewTabModule {}

--- a/src/crew-tab/crew-tab.service.ts
+++ b/src/crew-tab/crew-tab.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateCrewTabDto } from './dto/create-crew-tab.dto';
+import { UpdateCrewTabDto } from './dto/update-crew-tab.dto';
+
+@Injectable()
+export class CrewTabService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(crewId: string, dto: CreateCrewTabDto) {
+    return (this.prisma as any).crewTab.create({
+      data: {
+        crewId,
+        title: dto.title,
+        type: dto.type,
+        isVisible: dto.isVisible ?? true,
+        order: dto.order,
+        hashtag: dto.hashtag,
+      },
+    });
+  }
+
+  findCrewTabs(crewId: string) {
+    return (this.prisma as any).crewTab.findMany({
+      where: { crewId },
+      orderBy: { order: 'asc' },
+    });
+  }
+
+  update(id: string, dto: UpdateCrewTabDto) {
+    return (this.prisma as any).crewTab.update({
+      where: { id },
+      data: dto,
+    });
+  }
+
+  remove(id: string) {
+    return (this.prisma as any).crewTab.delete({ where: { id } });
+  }
+}

--- a/src/crew-tab/dto/create-crew-tab.dto.ts
+++ b/src/crew-tab/dto/create-crew-tab.dto.ts
@@ -1,0 +1,27 @@
+import {
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { CrewTabType } from 'src/prisma/crew-tab-type';
+
+export class CreateCrewTabDto {
+  @IsString()
+  title: string;
+
+  @IsEnum(CrewTabType)
+  type: CrewTabType;
+
+  @IsOptional()
+  @IsBoolean()
+  isVisible?: boolean;
+
+  @IsInt()
+  order: number;
+
+  @IsOptional()
+  @IsString()
+  hashtag?: string;
+}

--- a/src/crew-tab/dto/update-crew-tab.dto.ts
+++ b/src/crew-tab/dto/update-crew-tab.dto.ts
@@ -1,0 +1,30 @@
+import {
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import { CrewTabType } from 'src/prisma/crew-tab-type';
+
+export class UpdateCrewTabDto {
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsEnum(CrewTabType)
+  type?: CrewTabType;
+
+  @IsOptional()
+  @IsBoolean()
+  isVisible?: boolean;
+
+  @IsOptional()
+  @IsInt()
+  order?: number;
+
+  @IsOptional()
+  @IsString()
+  hashtag?: string;
+}

--- a/src/prisma/crew-tab-type.ts
+++ b/src/prisma/crew-tab-type.ts
@@ -1,0 +1,7 @@
+export enum CrewTabType {
+  OVERVIEW = 'OVERVIEW',
+  POSTS = 'POSTS',
+  NOTICE = 'NOTICE',
+  EVENT = 'EVENT',
+  TOPIC = 'TOPIC',
+}


### PR DESCRIPTION
## Summary
- add `CrewTab` Prisma model and enum
- generate migration for `CrewTab`
- implement crew tab controller, service, module
- export `CrewTabModule` in `AppModule`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b682ad6b083209c4f7a91d69a1c8a