### PR TITLE
Implement email verification workflow

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,6 +5,8 @@ import { RequestWithUser } from 'src/common/types/request-with-user';
 import { MeResponseDto } from './dto/me-response.dto';
 import { SignupDto } from './dto/signup.dto';
 import { LoginDto } from './dto/login.dto';
+import { RequestEmailVerificationDto } from './dto/request-email-verification.dto';
+import { VerifyEmailDto } from './dto/verify-email.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -27,5 +29,16 @@ export class AuthController {
   async login(@Body() loginDto: LoginDto) {
     const { email, password } = loginDto;
     return await this.authService.login(email, password);
+  }
+
+  @Post('request-email-verification')
+  requestVerification(@Body() dto: RequestEmailVerificationDto) {
+    return this.authService.requestEmailVerification(dto.email);
+  }
+
+  @Post('verify-email')
+  verifyEmail(@Body() dto: VerifyEmailDto) {
+    const { email, code } = dto;
+    return this.authService.verifyEmail(email, code);
   }
 }

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -33,6 +33,7 @@ describe('AuthService', () => {
       id: '1',
       email: 'a',
       passwordHash: 'hashed',
+      status: 'ACTIVE',
     });
     jest.spyOn(require('bcryptjs'), 'compare').mockResolvedValue(true as any);
     mockJwt.sign.mockReturnValue('token');

--- a/src/auth/dto/request-email-verification.dto.ts
+++ b/src/auth/dto/request-email-verification.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator';
+
+export class RequestEmailVerificationDto {
+  @IsEmail()
+  email: string;
+}

--- a/src/auth/dto/verify-email.dto.ts
+++ b/src/auth/dto/verify-email.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, IsString } from 'class-validator';
+
+export class VerifyEmailDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  code: string;
+}

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -20,8 +20,8 @@ describe('UserController (e2e) 테스트', () => {
     await app.close();
   });
 
-  it('POST /auth/signup - 회원가입', async () => {
-    const response = await request(app.getHttpServer())
+  it('signup and verify email', async () => {
+    const signup = await request(app.getHttpServer())
       .post('/auth/signup')
       .send({
         email: 'testuser2@example.com',
@@ -29,21 +29,22 @@ describe('UserController (e2e) 테스트', () => {
         password: '1234',
       });
 
-    expect(response.status).toBe(201); // default는 201 Created
-    expect(response.body).toHaveProperty('id');
-    expect(response.body.email).toBe('testuser2@example.com');
-  });
+    expect(signup.status).toBe(201);
 
-  it('POST /auth/login - 로그인', async () => {
-    const response = await request(app.getHttpServer())
+    const codeRes = await request(app.getHttpServer())
+      .post('/auth/request-email-verification')
+      .send({ email: 'testuser2@example.com' });
+    const code = codeRes.body.code as string;
+
+    const verify = await request(app.getHttpServer())
+      .post('/auth/verify-email')
+      .send({ email: 'testuser2@example.com', code });
+    expect(verify.status).toBe(201);
+
+    const login = await request(app.getHttpServer())
       .post('/auth/login')
-      .send({
-        email: 'testuser2@example.com',
-        password: '1234',
-      });
-
-    expect(response.status).toBe(201); // 또는 200
-    expect(response.body).toHaveProperty('id');
-    expect(response.body.email).toBe('testuser2@example.com');
+      .send({ email: 'testuser2@example.com', password: '1234' });
+    expect(login.status).toBe(201);
+    expect(login.body).toHaveProperty('accessToken');
   });
 });


### PR DESCRIPTION
## Summary
- add DTOs for requesting and verifying email codes
- extend `AuthController` with endpoints for email verification
- implement code generation/storage in `AuthService`
- enforce email verification for login
- test signup + verification flow

## Testing
- `npm test`
- `npm run test:e2e` *(fails: `@prisma/client did not initialize yet`)*


------
https://chatgpt.com/codex/tasks/task_e_6862862a75fc83209b6352771f4c0aab