### PR TITLE
Add user follow support

### DIFF
--- a/src/user/follow.controller.ts
+++ b/src/user/follow.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Delete, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { RequestWithUser } from 'src/common/types/request-with-user';
+import { FollowService } from './follow.service';
+
+@Controller('users')
+export class FollowController {
+  constructor(private readonly followService: FollowService) {}
+
+  @Get(':id/followers')
+  getFollowers(@Param('id') id: string) {
+    return this.followService.getFollowers(id);
+  }
+
+  @Get(':id/following')
+  getFollowing(@Param('id') id: string) {
+    return this.followService.getFollowing(id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/follow')
+  follow(@Param('id') id: string, @Req() req: RequestWithUser) {
+    return this.followService.follow(req.user.id, id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id/unfollow')
+  unfollow(@Param('id') id: string, @Req() req: RequestWithUser) {
+    return this.followService.unfollow(req.user.id, id);
+  }
+}

--- a/src/user/follow.service.ts
+++ b/src/user/follow.service.ts
@@ -1,0 +1,45 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class FollowService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  getFollowers(userId: string) {
+    return this.prisma.follow.findMany({
+      where: { followingId: userId },
+      include: {
+        follower: { select: { id: true, username: true } },
+      },
+    });
+  }
+
+  getFollowing(userId: string) {
+    return this.prisma.follow.findMany({
+      where: { followerId: userId },
+      include: {
+        following: { select: { id: true, username: true } },
+      },
+    });
+  }
+
+  async follow(userId: string, targetId: string) {
+    if (userId === targetId) {
+      throw new HttpException('Cannot follow yourself', HttpStatus.BAD_REQUEST);
+    }
+    try {
+      await this.prisma.follow.create({
+        data: { followerId: userId, followingId: targetId },
+      });
+    } catch (err) {
+      // ignore duplicate follow
+    }
+    return { followerId: userId, followingId: targetId };
+  }
+
+  async unfollow(userId: string, targetId: string) {
+    await this.prisma.follow.delete({
+      where: { followerId_followingId: { followerId: userId, followingId: targetId } },
+    }).catch(() => {});
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
+import { FollowService } from './follow.service';
+import { FollowController } from './follow.controller';
 
 @Module({
-  providers: [UserService],
-  controllers: [UserController],
+  providers: [UserService, FollowService],
+  controllers: [UserController, FollowController],
 })
 export class UserModule {}


### PR DESCRIPTION
## Summary
- implement `FollowService` for follow operations
- expose follow routes under `users` prefix
- register follow controller/service in `UserModule`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862862d2f20832098834d2b227d6a26