### PR TITLE
Implement brand role and status APIs

### DIFF
--- a/src/user/dto/approve-brand-role.dto.ts
+++ b/src/user/dto/approve-brand-role.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class ApproveBrandRoleDto {
+  @IsString()
+  userId: string;
+}

--- a/src/user/dto/update-user-status.dto.ts
+++ b/src/user/dto/update-user-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { UserStatus } from 'src/prisma/user-status';
+
+export class UpdateUserStatusDto {
+  @IsEnum(UserStatus)
+  status: UserStatus;
+}

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -1,9 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { UserStatus } from 'src/prisma/user-status';
+import { UserRole } from 'src/prisma/user-role';
 
 const mockUserService = {
   updateUser: jest.fn(),
+  updateStatus: jest.fn(),
+  requestBrandRole: jest.fn(),
+  approveBrandRole: jest.fn(),
 };
 
 
@@ -32,5 +37,33 @@ describe('UserController', () => {
 
     expect(mockUserService.updateUser).toHaveBeenCalledWith('1', dto);
     expect(result).toEqual({ id: '1' });
+  });
+
+  it('updateMyStatus calls service with user id and status', async () => {
+    mockUserService.updateStatus.mockResolvedValue({ id: '1', status: UserStatus.BANNED });
+    const req: any = { user: { id: '1' } };
+    const dto: any = { status: UserStatus.BANNED };
+    const result = await userController.updateMyStatus(req, dto);
+
+    expect(mockUserService.updateStatus).toHaveBeenCalledWith('1', UserStatus.BANNED);
+    expect(result).toEqual({ id: '1', status: UserStatus.BANNED });
+  });
+
+  it('requestBrandRole calls service with user id', async () => {
+    mockUserService.requestBrandRole.mockResolvedValue({ id: '1' });
+    const req: any = { user: { id: '1' } };
+    const result = await userController.requestBrandRole(req);
+
+    expect(mockUserService.requestBrandRole).toHaveBeenCalledWith('1');
+    expect(result).toEqual({ id: '1' });
+  });
+
+  it('approveBrandRole calls service with dto userId', async () => {
+    mockUserService.approveBrandRole.mockResolvedValue({ id: '2', role: UserRole.BRAND });
+    const dto: any = { userId: '2' };
+    const result = await userController.approveBrandRole(dto);
+
+    expect(mockUserService.approveBrandRole).toHaveBeenCalledWith('2');
+    expect(result).toEqual({ id: '2', role: UserRole.BRAND });
   });
 });

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Patch,
+  Post,
   Delete,
   Body,
   Req,
@@ -10,10 +11,12 @@ import {
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 
 import { UpdateUserDto } from './dto/update-user.dto';
+import { UpdateUserStatusDto } from './dto/update-user-status.dto';
+import { ApproveBrandRoleDto } from './dto/approve-brand-role.dto';
 import { UserService } from './user.service';
 import { RequestWithUser } from 'src/common/types/request-with-user';
 
-@Controller('user')
+@Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
@@ -34,6 +37,27 @@ export class UserController {
     @Body() updateDto: UpdateUserDto,
   ) {
     return await this.userService.updateUser(req.user.id, updateDto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('me/status')
+  updateMyStatus(
+    @Req() req: RequestWithUser,
+    @Body() dto: UpdateUserStatusDto,
+  ) {
+    return this.userService.updateStatus(req.user.id, dto.status);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('request-brand-role')
+  requestBrandRole(@Req() req: RequestWithUser) {
+    return this.userService.requestBrandRole(req.user.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('approve-brand-role')
+  approveBrandRole(@Body() dto: ApproveBrandRoleDto) {
+    return this.userService.approveBrandRole(dto.userId);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
 import { PrismaService } from '../prisma/prisma.service';
+import { UserStatus } from 'src/prisma/user-status';
+import { UserRole } from 'src/prisma/user-role';
 
 const mockPrismaService = {
   user: {
@@ -37,5 +39,41 @@ describe('UserService', () => {
       data: dto,
     });
     expect(result.id).toBe('1');
+  });
+
+  it('updateStatus updates user status', async () => {
+    mockPrismaService.user.update.mockResolvedValue({ id: '1', status: UserStatus.BANNED });
+
+    const result = await service.updateStatus('1', UserStatus.BANNED);
+
+    expect(mockPrismaService.user.update).toHaveBeenCalledWith({
+      where: { id: '1' },
+      data: { status: UserStatus.BANNED },
+    });
+    expect(result.status).toBe(UserStatus.BANNED);
+  });
+
+  it('requestBrandRole sets status inactive', async () => {
+    mockPrismaService.user.update.mockResolvedValue({ id: '1', status: UserStatus.INACTIVE });
+
+    const result = await service.requestBrandRole('1');
+
+    expect(mockPrismaService.user.update).toHaveBeenCalledWith({
+      where: { id: '1' },
+      data: { status: UserStatus.INACTIVE },
+    });
+    expect(result.status).toBe(UserStatus.INACTIVE);
+  });
+
+  it('approveBrandRole sets role brand and active', async () => {
+    mockPrismaService.user.update.mockResolvedValue({ id: '1', role: UserRole.BRAND, status: UserStatus.ACTIVE });
+
+    const result = await service.approveBrandRole('1');
+
+    expect(mockPrismaService.user.update).toHaveBeenCalledWith({
+      where: { id: '1' },
+      data: { role: UserRole.BRAND, status: UserStatus.ACTIVE },
+    });
+    expect(result.role).toBe(UserRole.BRAND);
   });
 });

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { UserStatus } from 'src/prisma/user-status';
+import { UserRole } from 'src/prisma/user-role';
 
 @Injectable()
 export class UserService {
@@ -15,5 +17,26 @@ export class UserService {
 
   async deleteUser(userId: string) {
     await this.prisma.user.delete({ where: { id: userId } });
+  }
+
+  async updateStatus(userId: string, status: UserStatus) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: { status },
+    });
+  }
+
+  async requestBrandRole(userId: string) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: { status: UserStatus.INACTIVE },
+    });
+  }
+
+  async approveBrandRole(userId: string) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: { role: UserRole.BRAND, status: UserStatus.ACTIVE },
+    });
   }
 }


### PR DESCRIPTION
## Summary
- implement user status update and brand role request/approval endpoints
- extend `UserService` with status and role update helpers
- create DTOs for new routes
- test new service and controller behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68628b4ab49c8320a5f45575ddc5e2e5