### PR TITLE
Enforce crew creator role and add tests

### DIFF
--- a/test/crew.e2e-spec.ts
+++ b/test/crew.e2e-spec.ts
@@ -3,9 +3,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
+import { PrismaService } from './../src/prisma/prisma.service';
 
 describe('CrewController (e2e)', () => {
   let app: INestApplication;
+  let prisma: PrismaService;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -14,6 +16,7 @@ describe('CrewController (e2e)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
+    prisma = app.get(PrismaService);
   });
 
   afterAll(async () => {
@@ -21,12 +24,23 @@ describe('CrewController (e2e)', () => {
   });
 
   it('/crew (POST)', async () => {
-    const login = await request(app.getHttpServer()).post('/auth/signup').send({
-      email: 'crewtest@example.com',
-      username: 'crewuser',
-      password: '1234',
+    const signup = await request(app.getHttpServer())
+      .post('/auth/signup')
+      .send({
+        email: 'crewtest@example.com',
+        username: 'crewuser',
+        password: '1234',
+      });
+
+    const userId = signup.body.id as string;
+    await prisma.user.update({
+      where: { id: userId },
+      data: { role: 'INFLUENCER', status: 'ACTIVE' },
     });
 
+    const login = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'crewtest@example.com', password: '1234' });
     const token = login.body.accessToken;
 
     const res = await request(app.getHttpServer())
@@ -36,6 +50,49 @@ describe('CrewController (e2e)', () => {
 
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id');
+  });
+
+  it('fails when creating a second crew', async () => {
+    const login = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'crewtest@example.com', password: '1234' });
+    const token = login.body.accessToken;
+
+    await request(app.getHttpServer())
+      .post('/crew')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'dup crew' });
+
+    const res = await request(app.getHttpServer())
+      .post('/crew')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'another crew' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('fails when user role is not influencer', async () => {
+    const signup = await request(app.getHttpServer())
+      .post('/auth/signup')
+      .send({
+        email: 'normal@example.com',
+        username: 'normal',
+        password: '1234',
+      });
+    const userId = signup.body.id as string;
+    await prisma.user.update({ where: { id: userId }, data: { status: 'ACTIVE' } });
+
+    const login = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'normal@example.com', password: '1234' });
+    const token = login.body.accessToken;
+
+    const res = await request(app.getHttpServer())
+      .post('/crew')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'should fail' });
+
+    expect(res.status).toBe(400);
   });
 
   it('/crew/:id (GET)', async () => {


### PR DESCRIPTION
## Summary
- enforce influencer role check and unique crew per owner in `CrewService.create`
- extend unit tests for crew creation failure scenarios
- update crew e2e tests and cover new constraints

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Prisma client failed to initialize)*

------
https://chatgpt.com/codex/tasks/task_e_68628b4bdae48320af879495301e88e6