### PR TITLE
Implement post visibility and mention parsing

### DIFF
--- a/src/post/dto/get-posts.dto.ts
+++ b/src/post/dto/get-posts.dto.ts
@@ -30,4 +30,8 @@ export class GetPostsDto {
   @IsOptional()
   @IsString()
   crewId?: string;
+
+  @IsOptional()
+  @IsString()
+  mention?: string;
 }

--- a/src/post/dto/update-post-visibility.dto.ts
+++ b/src/post/dto/update-post-visibility.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { PostVisibility } from 'src/prisma/post-visibility';
+
+export class UpdatePostVisibilityDto {
+  @IsEnum(PostVisibility)
+  visibility: PostVisibility;
+}

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -14,6 +14,7 @@ import {
 import { PostService } from './post.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
+import { UpdatePostVisibilityDto } from './dto/update-post-visibility.dto';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 import { RequestWithUser } from 'src/common/types/request-with-user';
 import { GetPostsDto } from './dto/get-posts.dto';
@@ -46,6 +47,21 @@ export class PostController {
     @Req() req: RequestWithUser,
   ) {
     return this.postService.updatePost(id, dto, req.user.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch(':id/visibility')
+  async updateVisibility(
+    @Param('id') id: string,
+    @Body() dto: UpdatePostVisibilityDto,
+    @Req() req: RequestWithUser,
+  ) {
+    return this.postService.updatePostVisibility(id, dto.visibility, req.user.id);
+  }
+
+  @Post(':id/parse-mentions')
+  async parseMentions(@Param('id') id: string) {
+    return this.postService.parseMentions(id);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -3,13 +3,19 @@ import { PostService } from './post.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { HttpException } from '@nestjs/common';
 import { UpdatePostDto } from './dto/update-post.dto';
+import { PostVisibility } from 'src/prisma/post-visibility';
+import { PostType } from 'src/prisma/post-type';
 
 const mockPrismaService = {
   post: {
     findUnique: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+    create: jest.fn(),
   },
+  user: { findUnique: jest.fn() },
+  crew: { findUnique: jest.fn() },
+  crewMember: { findUnique: jest.fn() },
 };
 
 describe('PostService 서비스', () => {
@@ -73,6 +79,41 @@ describe('PostService 서비스', () => {
     mockPrismaService.post.findUnique.mockResolvedValue(null);
 
     await expect(service.deletePost('1', 'user1')).rejects.toBeInstanceOf(
+      HttpException,
+    );
+  });
+
+  it('작성자가 게시글 공개 범위를 수정할 수 있다', async () => {
+    mockPrismaService.post.findUnique.mockResolvedValue({
+      id: '1',
+      authorId: 'user1',
+    });
+    mockPrismaService.post.update.mockResolvedValue({
+      id: '1',
+      visibility: PostVisibility.CREW_ONLY,
+    });
+
+    const result = await service.updatePostVisibility(
+      '1',
+      PostVisibility.CREW_ONLY,
+      'user1',
+    );
+
+    expect(mockPrismaService.post.update).toHaveBeenCalledWith({
+      where: { id: '1' },
+      data: { visibility: PostVisibility.CREW_ONLY },
+    });
+    expect(result.visibility).toBe(PostVisibility.CREW_ONLY);
+  });
+
+  it('COLUMN 타입 게시글은 crewId 없으면 생성 불가', async () => {
+    const dto: any = {
+      type: PostType.COLUMN,
+      title: 't',
+      content: {},
+    };
+
+    await expect(service.createPost(dto, 'u1')).rejects.toBeInstanceOf(
       HttpException,
     );
   });

--- a/src/prisma/crew-member-role.ts
+++ b/src/prisma/crew-member-role.ts
@@ -1,0 +1,5 @@
+export enum CrewMemberRole {
+  OWNER = 'OWNER',
+  MANAGER = 'MANAGER',
+  MEMBER = 'MEMBER',
+}


### PR DESCRIPTION
## Summary
- add crew member role enum
- support mention query in GetPostsDto
- create endpoint to modify post visibility
- allow parsing mentions from post content
- enforce COLUMN creation permissions
- unit tests for new service behaviors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68628b561bd88320ad3e54b520bf4357