### PR TITLE
Implement crew member management API

### DIFF
--- a/src/crew-member/crew-member.controller.ts
+++ b/src/crew-member/crew-member.controller.ts
@@ -1,14 +1,25 @@
-import { Controller, Param, Post, UseGuards, Req, Get, Body } from '@nestjs/common';
+import {
+  Controller,
+  Param,
+  Post,
+  UseGuards,
+  Req,
+  Get,
+  Body,
+  Patch,
+  Delete,
+} from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 import { RequestWithUser } from 'src/common/types/request-with-user';
 import { CrewMemberService } from './crew-member.service';
+import { CrewMemberRole } from 'src/prisma/crew-member-role';
 
-@Controller('crew')
+@Controller()
 export class CrewMemberController {
   constructor(private readonly service: CrewMemberService) {}
 
   @UseGuards(JwtAuthGuard)
-  @Post(':crewId/join')
+  @Post('crew/:crewId/join')
   join(
     @Param('crewId') crewId: string,
     @Req() req: RequestWithUser,
@@ -18,8 +29,34 @@ export class CrewMemberController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Get('me/memberships')
+  @Get('crew/me/memberships')
   listMine(@Req() req: RequestWithUser) {
     return this.service.listUserCrews(req.user.id);
+  }
+
+  @Get('crews/:crewId/members')
+  list(@Param('crewId') crewId: string) {
+    return this.service.listCrewMembers(crewId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('crews/:crewId/members/:userId/role')
+  changeRole(
+    @Param('crewId') crewId: string,
+    @Param('userId') userId: string,
+    @Body('role') role: CrewMemberRole,
+    @Req() req: RequestWithUser,
+  ) {
+    return this.service.changeRole(crewId, userId, role, req.user.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete('crews/:crewId/members/:userId')
+  remove(
+    @Param('crewId') crewId: string,
+    @Param('userId') userId: string,
+    @Req() req: RequestWithUser,
+  ) {
+    return this.service.removeMember(crewId, userId, req.user.id);
   }
 }

--- a/src/crew-member/crew-member.module.ts
+++ b/src/crew-member/crew-member.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { CrewPermissionModule } from 'src/crew-permission/crew-permission.module';
 import { CrewMemberController } from './crew-member.controller';
 import { CrewMemberService } from './crew-member.service';
 
 @Module({
+  imports: [CrewPermissionModule],
   controllers: [CrewMemberController],
   providers: [CrewMemberService],
 })

--- a/src/crew-member/crew-member.service.ts
+++ b/src/crew-member/crew-member.service.ts
@@ -1,9 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { CrewPermissionService } from 'src/crew-permission/crew-permission.service';
+import { CrewPermissionAction } from 'src/prisma/crew-permission-action';
+import { CrewMemberRole } from 'src/prisma/crew-member-role';
 
 @Injectable()
 export class CrewMemberService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly permission: CrewPermissionService,
+  ) {}
 
   async join(crewId: string, userId: string, roleId: number) {
     return this.prisma.crewMember.create({
@@ -15,6 +21,65 @@ export class CrewMemberService {
     return this.prisma.crewMember.findMany({
       where: { userId },
       include: { crew: true },
+    });
+  }
+
+  listCrewMembers(crewId: string) {
+    return this.prisma.crewMember.findMany({
+      where: { crewId },
+      include: {
+        user: { select: { id: true, username: true } },
+      },
+    });
+  }
+
+  async changeRole(
+    crewId: string,
+    targetId: string,
+    role: CrewMemberRole,
+    actorId: string,
+  ) {
+    const allowed = await this.permission.hasPermission(
+      crewId,
+      actorId,
+      CrewPermissionAction.MANAGE_MEMBER,
+    );
+    if (!allowed) {
+      throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);
+    }
+
+    const member = await this.prisma.crewMember.findUnique({
+      where: { crewId_userId: { crewId, userId: targetId } },
+    });
+    if (!member) {
+      throw new HttpException('Member not found', HttpStatus.NOT_FOUND);
+    }
+
+    return this.prisma.crewMember.update({
+      where: { crewId_userId: { crewId, userId: targetId } },
+      data: { role },
+    });
+  }
+
+  async removeMember(crewId: string, targetId: string, actorId: string) {
+    const allowed = await this.permission.hasPermission(
+      crewId,
+      actorId,
+      CrewPermissionAction.MANAGE_MEMBER,
+    );
+    if (!allowed) {
+      throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);
+    }
+
+    const member = await this.prisma.crewMember.findUnique({
+      where: { crewId_userId: { crewId, userId: targetId } },
+    });
+    if (!member) {
+      throw new HttpException('Member not found', HttpStatus.NOT_FOUND);
+    }
+
+    await this.prisma.crewMember.delete({
+      where: { crewId_userId: { crewId, userId: targetId } },
     });
   }
 }

--- a/src/prisma/crew-member-role.ts
+++ b/src/prisma/crew-member-role.ts
@@ -1,0 +1,5 @@
+export enum CrewMemberRole {
+  OWNER = 'OWNER',
+  MANAGER = 'MANAGER',
+  MEMBER = 'MEMBER',
+}


### PR DESCRIPTION
## Summary
- add crew member role enum
- extend CrewMemberService with management operations
- wire up CrewMemberController endpoints for listing and managing members
- import CrewPermissionModule into CrewMemberModule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68628defe3348320be60a99e4677e5ef