### PR TITLE
Add Topic module

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -279,8 +279,17 @@ model CrewTabConfig {
   type        CrewTabType
   order       Int
   hashtag     String?
+  topic       Topic?      @relation(fields: [topicId], references: [id])
+  topicId     String?
   isVisible   Boolean     @default(true)
   createdAt   DateTime    @default(now())
+}
+
+model Topic {
+  id        String         @id @default(uuid())
+  hashtag   String         @unique
+  crewTabs  CrewTabConfig[]
+  createdAt DateTime       @default(now())
 }
 
 model ContentReport {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { CrewTabModule } from './crew-tab/crew-tab.module';
 import { CrewPermissionModule } from './crew-permission/crew-permission.module';
 import { ReportModule } from './report/report.module';
 import { SponsorshipModule } from './sponsorship/sponsorship.module';
+import { TopicModule } from './topic/topic.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { SponsorshipModule } from './sponsorship/sponsorship.module';
     CrewTabModule,
     SponsorshipModule,
     ReportModule,
+    TopicModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/topic/dto/create-topic.dto.ts
+++ b/src/topic/dto/create-topic.dto.ts
@@ -1,0 +1,11 @@
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+export class CreateTopicDto {
+  @IsString()
+  hashtag: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tabIds?: string[];
+}

--- a/src/topic/topic.controller.ts
+++ b/src/topic/topic.controller.ts
@@ -1,0 +1,15 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { CreateTopicDto } from './dto/create-topic.dto';
+import { TopicService } from './topic.service';
+
+@Controller()
+export class TopicController {
+  constructor(private readonly service: TopicService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post('topics')
+  create(@Body() dto: CreateTopicDto) {
+    return this.service.create(dto);
+  }
+}

--- a/src/topic/topic.module.ts
+++ b/src/topic/topic.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TopicService } from './topic.service';
+import { TopicController } from './topic.controller';
+
+@Module({
+  controllers: [TopicController],
+  providers: [TopicService],
+})
+export class TopicModule {}

--- a/src/topic/topic.service.ts
+++ b/src/topic/topic.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateTopicDto } from './dto/create-topic.dto';
+
+@Injectable()
+export class TopicService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateTopicDto) {
+    const topic = await (this.prisma as any).topic.create({
+      data: { hashtag: dto.hashtag },
+    });
+
+    if (dto.tabIds?.length) {
+      await (this.prisma as any).crewTab.updateMany({
+        where: { id: { in: dto.tabIds } },
+        data: { topicId: topic.id, hashtag: dto.hashtag },
+      });
+    }
+
+    return topic;
+  }
+}

--- a/test/topic.e2e-spec.ts
+++ b/test/topic.e2e-spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('TopicController (e2e)', () => {
+  let app: INestApplication;
+  let token: string;
+  let crewId: string;
+  let tabId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    const signup = await request(app.getHttpServer())
+      .post('/auth/signup')
+      .send({ email: 'topic@test.com', username: 'topicer', password: '1234' });
+    token = signup.body.accessToken;
+
+    const crew = await request(app.getHttpServer())
+      .post('/crew')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'topic crew' });
+    crewId = crew.body.id;
+
+    const tab = await request(app.getHttpServer())
+      .post(`/crew/${crewId}/tabs`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'topic tab', type: 'TOPIC', order: 1 });
+    tabId = tab.body.id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/topics (POST)', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/topics')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ hashtag: '#test', tabIds: [tabId] });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('id');
+
+    const tabs = await request(app.getHttpServer()).get(`/crew/${crewId}/tabs`);
+    expect(tabs.body[0].hashtag).toBe('#test');
+  });
+});


### PR DESCRIPTION
## Summary
- add TopicModule with controller/service
- enable `POST /topics` for registering hashtags and linking to crew tabs
- extend Prisma schema with Topic model and relation to crew tabs
- include basic e2e spec for topic creation

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Prisma client not generated)*

------
https://chatgpt.com/codex/tasks/task_e_68628df07ed883208a8d738117eedda3