### PR TITLE
Add Stripe sponsorship endpoints

### DIFF
--- a/src/sponsorship/dto/create-sponsorship.dto.ts
+++ b/src/sponsorship/dto/create-sponsorship.dto.ts
@@ -1,0 +1,11 @@
+import { IsInt, IsUUID, Min, Max } from 'class-validator';
+
+export class CreateSponsorshipDto {
+  @IsUUID()
+  crewId: string;
+
+  @IsInt()
+  @Min(1000)
+  @Max(1000000)
+  amount: number;
+}

--- a/src/sponsorship/sponsorship.controller.ts
+++ b/src/sponsorship/sponsorship.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
 import { RequestWithUser } from 'src/common/types/request-with-user';
 import { ValidateSponsorshipDto } from './dto/validate-sponsorship.dto';
+import { CreateSponsorshipDto } from './dto/create-sponsorship.dto';
 import { SponsorshipService } from './sponsorship.service';
 
 @Controller('sponsorships')
@@ -12,5 +13,16 @@ export class SponsorshipController {
   @Post('validate')
   validate(@Body() dto: ValidateSponsorshipDto, @Req() req: RequestWithUser) {
     return this.sponsorshipService.validate(dto, req.user.id);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  create(@Body() dto: CreateSponsorshipDto, @Req() req: RequestWithUser) {
+    return this.sponsorshipService.create(dto, req.user.id);
+  }
+
+  @Post('webhook')
+  webhook(@Body() body: unknown) {
+    return this.sponsorshipService.handleWebhook(body);
   }
 }

--- a/src/sponsorship/sponsorship.module.ts
+++ b/src/sponsorship/sponsorship.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { SponsorshipController } from './sponsorship.controller';
 import { SponsorshipService } from './sponsorship.service';
 
 @Module({
+  imports: [ConfigModule],
   controllers: [SponsorshipController],
   providers: [SponsorshipService],
 })

--- a/test/sponsorship.e2e-spec.ts
+++ b/test/sponsorship.e2e-spec.ts
@@ -45,4 +45,32 @@ describe('SponsorshipController (e2e)', () => {
     expect(res.status).toBe(201);
     expect(res.body.valid).toBe(true);
   });
+
+  it('/sponsorships (POST)', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/sponsorships')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ crewId, amount: 3000 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.url).toBeDefined();
+  });
+
+  it('/sponsorships/webhook (POST)', async () => {
+    const payload = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          metadata: { crewId, sponsorId: 'dummy' },
+          amount_total: 3000,
+        },
+      },
+    };
+    const res = await request(app.getHttpServer())
+      .post('/sponsorships/webhook')
+      .send(payload);
+
+    expect(res.status).toBe(201);
+    expect(res.body.received).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- enable payment initiation and webhook for Sponsorships
- support config module in sponsorship module
- create DTO for sponsorship creation
- expand e2e coverage

## Testing
- `npm test`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npm run test:e2e` *(fails: `@prisma/client did not initialize yet`)*

------
https://chatgpt.com/codex/tasks/task_e_68628ff8d00c8320ba1da6b7d40488a9