### PR TITLE
Implement AdCampaign module

### DIFF
--- a/src/ad-campaign/ad-campaign.controller.spec.ts
+++ b/src/ad-campaign/ad-campaign.controller.spec.ts
@@ -1,0 +1,41 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdCampaignController } from './ad-campaign.controller';
+import { AdCampaignService } from './ad-campaign.service';
+import { AdCampaignStatus } from 'src/prisma/ad-campaign-status';
+
+const mockService = {
+  create: jest.fn(),
+  updateStatus: jest.fn(),
+};
+
+describe('AdCampaignController', () => {
+  let controller: AdCampaignController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdCampaignController],
+      providers: [{ provide: AdCampaignService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get<AdCampaignController>(AdCampaignController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('calls service on create', async () => {
+    mockService.create.mockResolvedValue({ id: 'c1' });
+    const dto: any = {};
+    const req: any = { user: { id: 'b1' } };
+    const result = await controller.create(dto, req);
+    expect(mockService.create).toHaveBeenCalledWith(dto, 'b1');
+    expect(result.id).toBe('c1');
+  });
+
+  it('calls service on status update', async () => {
+    mockService.updateStatus.mockResolvedValue({ id: 'c1', status: AdCampaignStatus.RUNNING });
+    const dto: any = { status: AdCampaignStatus.RUNNING };
+    const result = await controller.updateStatus('c1', dto);
+    expect(mockService.updateStatus).toHaveBeenCalledWith('c1', AdCampaignStatus.RUNNING);
+    expect(result.status).toBe(AdCampaignStatus.RUNNING);
+  });
+});

--- a/src/ad-campaign/ad-campaign.controller.ts
+++ b/src/ad-campaign/ad-campaign.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
+import { RequestWithUser } from 'src/common/types/request-with-user';
+import { AdCampaignService } from './ad-campaign.service';
+import { CreateAdCampaignDto } from './dto/create-ad-campaign.dto';
+import { UpdateAdCampaignStatusDto } from './dto/update-ad-campaign-status.dto';
+
+@Controller('ad-campaigns')
+export class AdCampaignController {
+  constructor(private readonly adCampaignService: AdCampaignService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  create(@Body() dto: CreateAdCampaignDto, @Req() req: RequestWithUser) {
+    return this.adCampaignService.create(dto, req.user.id);
+  }
+
+  @Patch(':id/status')
+  updateStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateAdCampaignStatusDto,
+  ) {
+    return this.adCampaignService.updateStatus(id, dto.status);
+  }
+}

--- a/src/ad-campaign/ad-campaign.module.ts
+++ b/src/ad-campaign/ad-campaign.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AdCampaignController } from './ad-campaign.controller';
+import { AdCampaignService } from './ad-campaign.service';
+
+@Module({
+  controllers: [AdCampaignController],
+  providers: [AdCampaignService],
+})
+export class AdCampaignModule {}

--- a/src/ad-campaign/ad-campaign.service.spec.ts
+++ b/src/ad-campaign/ad-campaign.service.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdCampaignService } from './ad-campaign.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { UserRole } from 'src/prisma/user-role';
+import { AdCampaignStatus } from 'src/prisma/ad-campaign-status';
+
+const mockPrisma = {
+  adCampaign: {
+    create: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+  },
+  user: {
+    findUnique: jest.fn(),
+  },
+};
+
+describe('AdCampaignService', () => {
+  let service: AdCampaignService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdCampaignService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<AdCampaignService>(AdCampaignService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows brand users to create campaign', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({ id: 'b1', role: UserRole.BRAND });
+    mockPrisma.adCampaign.create.mockResolvedValue({ id: 'c1' });
+
+    const dto: any = { crewId: 'crew', content: 'ad', bannerUrl: 'url', budget: 1, startsAt: new Date().toISOString(), endsAt: new Date().toISOString() };
+    const result = await service.create(dto, 'b1');
+
+    expect(mockPrisma.adCampaign.create).toHaveBeenCalled();
+    expect(result.id).toBe('c1');
+  });
+
+  it('rejects non-brand user creation', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({ id: 'u1', role: UserRole.USER });
+    const dto: any = { crewId: 'c', content: 'ad', bannerUrl: 'b', budget: 1, startsAt: '', endsAt: '' };
+    await expect(service.create(dto, 'u1')).rejects.toBeDefined();
+  });
+
+  it('validates status transitions', async () => {
+    mockPrisma.adCampaign.findUnique.mockResolvedValue({ id: 'c1', status: AdCampaignStatus.PENDING });
+    mockPrisma.adCampaign.update.mockResolvedValue({ id: 'c1', status: AdCampaignStatus.RUNNING });
+
+    const result = await service.updateStatus('c1', AdCampaignStatus.RUNNING);
+    expect(mockPrisma.adCampaign.update).toHaveBeenCalledWith({ where: { id: 'c1' }, data: { status: AdCampaignStatus.RUNNING } });
+    expect(result.status).toBe(AdCampaignStatus.RUNNING);
+  });
+});

--- a/src/ad-campaign/ad-campaign.service.ts
+++ b/src/ad-campaign/ad-campaign.service.ts
@@ -1,0 +1,52 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { UserRole } from 'src/prisma/user-role';
+import { AdCampaignStatus } from 'src/prisma/ad-campaign-status';
+import { CreateAdCampaignDto } from './dto/create-ad-campaign.dto';
+
+@Injectable()
+export class AdCampaignService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateAdCampaignDto, brandId: string) {
+    const brand = await this.prisma.user.findUnique({ where: { id: brandId } });
+    if (!brand || brand.role !== UserRole.BRAND) {
+      throw new BadRequestException('Only brands can create ad campaigns');
+    }
+
+    const { crewId, content, bannerUrl, budget, startsAt, endsAt } = dto;
+    return this.prisma.adCampaign.create({
+      data: {
+        brandId,
+        crewId,
+        content,
+        bannerUrl,
+        budget,
+        startsAt: new Date(startsAt),
+        endsAt: new Date(endsAt),
+        status: AdCampaignStatus.PENDING,
+      },
+    });
+  }
+
+  async updateStatus(id: string, status: AdCampaignStatus) {
+    const campaign = await this.prisma.adCampaign.findUnique({ where: { id } });
+    if (!campaign) throw new NotFoundException('Campaign not found');
+
+    if (!this.isValidTransition(campaign.status as AdCampaignStatus, status)) {
+      throw new BadRequestException('Invalid status transition');
+    }
+
+    return this.prisma.adCampaign.update({ where: { id }, data: { status } });
+  }
+
+  isValidTransition(current: AdCampaignStatus, next: AdCampaignStatus) {
+    const map: Record<AdCampaignStatus, AdCampaignStatus[]> = {
+      [AdCampaignStatus.PENDING]: [AdCampaignStatus.RUNNING, AdCampaignStatus.CANCELLED],
+      [AdCampaignStatus.RUNNING]: [AdCampaignStatus.COMPLETED, AdCampaignStatus.CANCELLED],
+      [AdCampaignStatus.COMPLETED]: [],
+      [AdCampaignStatus.CANCELLED]: [],
+    };
+    return map[current]?.includes(next);
+  }
+}

--- a/src/ad-campaign/dto/create-ad-campaign.dto.ts
+++ b/src/ad-campaign/dto/create-ad-campaign.dto.ts
@@ -1,0 +1,21 @@
+import { IsString, IsInt, IsDateString } from 'class-validator';
+
+export class CreateAdCampaignDto {
+  @IsString()
+  crewId: string;
+
+  @IsString()
+  content: string;
+
+  @IsString()
+  bannerUrl: string;
+
+  @IsInt()
+  budget: number;
+
+  @IsDateString()
+  startsAt: string;
+
+  @IsDateString()
+  endsAt: string;
+}

--- a/src/ad-campaign/dto/update-ad-campaign-status.dto.ts
+++ b/src/ad-campaign/dto/update-ad-campaign-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { AdCampaignStatus } from 'src/prisma/ad-campaign-status';
+
+export class UpdateAdCampaignStatusDto {
+  @IsEnum(AdCampaignStatus)
+  status: AdCampaignStatus;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { CrewTabModule } from './crew-tab/crew-tab.module';
 import { CrewPermissionModule } from './crew-permission/crew-permission.module';
 import { ReportModule } from './report/report.module';
 import { SponsorshipModule } from './sponsorship/sponsorship.module';
+import { AdCampaignModule } from './ad-campaign/ad-campaign.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { SponsorshipModule } from './sponsorship/sponsorship.module';
     CrewTabModule,
     SponsorshipModule,
     ReportModule,
+    AdCampaignModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/prisma/ad-campaign-status.ts
+++ b/src/prisma/ad-campaign-status.ts
@@ -1,0 +1,6 @@
+export enum AdCampaignStatus {
+  PENDING = 'PENDING',
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED',
+}


### PR DESCRIPTION
## Summary
- add `AdCampaignModule` with controller and service
- allow only brands to create ad campaigns
- add endpoint to update campaign status with validation
- expose `AdCampaignStatus` enum
- wire new module into `AppModule`
- add unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68628ff9b428832098f762e49a34a790