### PR TITLE
Add notification template module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { CrewTabModule } from './crew-tab/crew-tab.module';
 import { CrewPermissionModule } from './crew-permission/crew-permission.module';
 import { ReportModule } from './report/report.module';
 import { SponsorshipModule } from './sponsorship/sponsorship.module';
+import { NotificationTemplateModule } from './notification-template/notification-template.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { SponsorshipModule } from './sponsorship/sponsorship.module';
     CrewTabModule,
     SponsorshipModule,
     ReportModule,
+    NotificationTemplateModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/notification-template/dto/create-notification-template.dto.ts
+++ b/src/notification-template/dto/create-notification-template.dto.ts
@@ -1,0 +1,9 @@
+import { IsString } from 'class-validator';
+
+export class CreateNotificationTemplateDto {
+  @IsString()
+  code: string;
+
+  @IsString()
+  message: string;
+}

--- a/src/notification-template/dto/update-notification-template.dto.ts
+++ b/src/notification-template/dto/update-notification-template.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateNotificationTemplateDto {
+  @IsOptional()
+  @IsString()
+  code?: string;
+
+  @IsOptional()
+  @IsString()
+  message?: string;
+}

--- a/src/notification-template/notification-template.controller.ts
+++ b/src/notification-template/notification-template.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { NotificationTemplateService } from './notification-template.service';
+import { CreateNotificationTemplateDto } from './dto/create-notification-template.dto';
+
+@Controller('notification-templates')
+export class NotificationTemplateController {
+  constructor(private readonly service: NotificationTemplateService) {}
+
+  @Post()
+  create(@Body() dto: CreateNotificationTemplateDto) {
+    return this.service.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+}

--- a/src/notification-template/notification-template.module.ts
+++ b/src/notification-template/notification-template.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { NotificationTemplateService } from './notification-template.service';
+import { NotificationTemplateController } from './notification-template.controller';
+
+@Module({
+  controllers: [NotificationTemplateController],
+  providers: [NotificationTemplateService],
+})
+export class NotificationTemplateModule {}

--- a/src/notification-template/notification-template.service.ts
+++ b/src/notification-template/notification-template.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateNotificationTemplateDto } from './dto/create-notification-template.dto';
+import { UpdateNotificationTemplateDto } from './dto/update-notification-template.dto';
+
+@Injectable()
+export class NotificationTemplateService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  create(dto: CreateNotificationTemplateDto) {
+    return this.prisma.notificationTemplate.create({ data: dto });
+  }
+
+  findAll() {
+    return this.prisma.notificationTemplate.findMany({
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  findOne(id: string) {
+    return this.prisma.notificationTemplate.findUnique({ where: { id } });
+  }
+
+  update(id: string, dto: UpdateNotificationTemplateDto) {
+    return this.prisma.notificationTemplate.update({ where: { id }, data: dto });
+  }
+
+  remove(id: string) {
+    return this.prisma.notificationTemplate.delete({ where: { id } });
+  }
+}


### PR DESCRIPTION
## Summary
- add NotificationTemplateModule with CRUD service
- expose `/notification-templates` GET and POST endpoints
- register the module in `AppModule`

## Testing
- `npm test`
- `npm run lint` *(fails: 333 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68628ffab8248320aa7d205b0a548f00