### PR TITLE
Add user profile lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,72 @@
 - Event 모델과 후원 필드 등 v2 기능을 반영하여 Prisma 스키마를 수정했습니다.
 - CREW 멤버십 API와 전용 게시글, 이벤트 관리 기능을 추가했습니다.
 
+
+## REST API Checklist
+
+### 🔐 인증 & 회원가입
+- [x] `POST /auth/signup`
+- [x] `POST /auth/verify-email`
+- [x] `POST /auth/request-email-verification`
+
+### 👤 유저
+- [x] `GET /users/:id`
+- [x] `GET /users/:id/followers`
+- [x] `GET /users/:id/following`
+- [x] `POST /users/:id/follow`
+- [x] `DELETE /users/:id/unfollow`
+- [x] `PATCH /users/me/status`
+- [x] `POST /users/request-brand-role`
+- [x] `POST /users/approve-brand-role`
+
+### 🧑‍🤝‍🧑 크루
+- [x] `POST /crews`
+- [x] `GET /crews/:id`
+- [x] `POST /crews/:id/join`
+- [x] `POST /crews/:id/leave`
+- [x] `PATCH /crews/:id/status`
+- [x] `PATCH /crews/:id/transfer-ownership`
+
+### 👥 크루 멤버
+- [ ] `GET /crews/:crewId/members`
+- [ ] `PATCH /crews/:crewId/members/:userId/role`
+- [ ] `DELETE /crews/:crewId/members/:userId`
+
+### 🧷 크루탭/토픽
+- [x] `POST /crews/:crewId/tabs`
+- [x] `PATCH /crews/:crewId/tabs/:tabId`
+- [x] `DELETE /crews/:crewId/tabs/:tabId`
+- [x] `POST /topics`
+
+### 📝 게시글
+- [x] `POST /posts`
+- [x] `PATCH /posts/:id`
+- [x] `DELETE /posts/:id`
+- [x] `PATCH /posts/:id/visibility`
+- [x] `GET /posts?mention=crewId`
+- [x] `GET /posts?type=`
+- [x] `POST /posts/:id/parse-mentions`
+
+### 💰 후원
+- [x] `POST /sponsorships`
+- [x] `POST /sponsorships/webhook`
+- [x] `POST /sponsorships/validate`
+
+### 📢 광고
+- [x] `POST /ad-campaigns`
+- [x] `PATCH /ad-campaigns/:id/status`
+
+### ⚠️ 신고
+- [x] `POST /reports`
+- [x] `GET /reports?status=pending`
+- [x] `PATCH /reports/:id/resolve`
+
+### 🔔 알림 템플릿
+- [x] `GET /notification-templates`
+- [x] `POST /notification-templates`
+
+### ⚙️ 설정 정보
+- [ ] `GET /config/post-types`
+- [ ] `GET /config/user-roles`
+- [ ] `GET /config/crew-status`
+- [ ] `GET /config/post-visibility`

--- a/src/crew/crew.module.ts
+++ b/src/crew/crew.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CrewService } from './crew.service';
 import { CrewController } from './crew.controller';
+import { PostModule } from 'src/post/post.module';
 
 @Module({
+  imports: [PostModule],
   controllers: [CrewController],
   providers: [CrewService],
   exports: [CrewService],

--- a/src/post/post.module.ts
+++ b/src/post/post.module.ts
@@ -18,5 +18,6 @@ import { AuthService } from 'src/auth/auth.service';
     JwtStrategy,
     JwtAuthGuard,
   ],
+  exports: [PostService],
 })
 export class PostModule {}

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -5,6 +5,7 @@ import { UserStatus } from 'src/prisma/user-status';
 import { UserRole } from 'src/prisma/user-role';
 
 const mockUserService = {
+  getUserById: jest.fn(),
   updateUser: jest.fn(),
   updateStatus: jest.fn(),
   requestBrandRole: jest.fn(),
@@ -26,6 +27,15 @@ describe('UserController', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('getUser calls service with id', async () => {
+    mockUserService.getUserById.mockResolvedValue({ id: '1' });
+
+    const result = await userController.getUser('1');
+
+    expect(mockUserService.getUserById).toHaveBeenCalledWith('1');
+    expect(result).toEqual({ id: '1' });
   });
 
   it('updateMe calls service with user id', async () => {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Body,
   Req,
+  Param,
   UseGuards,
 } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
@@ -19,6 +20,11 @@ import { RequestWithUser } from 'src/common/types/request-with-user';
 @Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
+
+  @Get(':id')
+  getUser(@Param('id') id: string) {
+    return this.userService.getUserById(id);
+  }
 
   @UseGuards(JwtAuthGuard)
   @Get('me')

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -6,6 +6,7 @@ import { UserRole } from 'src/prisma/user-role';
 
 const mockPrismaService = {
   user: {
+    findUnique: jest.fn(),
     update: jest.fn(),
   },
 };
@@ -26,6 +27,25 @@ describe('UserService', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('getUserById retrieves user with selected fields', async () => {
+    mockPrismaService.user.findUnique.mockResolvedValue({ id: '1', username: 'u' });
+
+    const result = await service.getUserById('1');
+
+    expect(mockPrismaService.user.findUnique).toHaveBeenCalledWith({
+      where: { id: '1' },
+      select: {
+        id: true,
+        username: true,
+        avatarUrl: true,
+        bio: true,
+        role: true,
+        status: true,
+      },
+    });
+    expect(result?.id).toBe('1');
   });
 
   it('updateUser calls prisma update with dto', async () => {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -8,6 +8,20 @@ import { UserRole } from 'src/prisma/user-role';
 export class UserService {
   constructor(private readonly prisma: PrismaService) {}
 
+  getUserById(userId: string) {
+    return this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        username: true,
+        avatarUrl: true,
+        bio: true,
+        role: true,
+        status: true,
+      },
+    });
+  }
+
   async updateUser(userId: string, updateUserDto: UpdateUserDto) {
     return this.prisma.user.update({
       where: { id: userId },


### PR DESCRIPTION
## Summary
- add GET /users/:id endpoint
- implement `getUserById` in service
- cover new functionality with unit tests
- document existing and missing REST endpoints

## Testing
- `npm test`
- `npm run test:e2e` *(fails: DATABASE_URL missing)*

------
https://chatgpt.com/codex/tasks/task_e_686379b46e508320b087f9bea24ed0f8