### PR TITLE
Implement config API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@
 - [ ] Vitest 기반 단위 테스트 작성
 - [ ] Playwright E2E 테스트 작성
 - [ ] UX 개선 및 디자인 피드백 반영
+- [ ] COLUMN 작성 권한 제한 (일반 유저 작성 시 에러 처리)
+- [ ] OWNER 승계 실패 시 CREW 상태 비공개 전환
 
 ## 🔄 최근 업데이트
 
@@ -149,7 +151,7 @@
 - [x] `POST /notification-templates`
 
 ### ⚙️ 설정 정보
-- [ ] `GET /config/post-types`
-- [ ] `GET /config/user-roles`
-- [ ] `GET /config/crew-status`
-- [ ] `GET /config/post-visibility`
+- [x] `GET /config/post-types`
+- [x] `GET /config/user-roles`
+- [x] `GET /config/crew-status`
+- [x] `GET /config/post-visibility`

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,6 +17,7 @@ import { SponsorshipModule } from './sponsorship/sponsorship.module';
 import { NotificationTemplateModule } from './notification-template/notification-template.module';
 import { AdCampaignModule } from './ad-campaign/ad-campaign.module';
 import { TopicModule } from './topic/topic.module';
+import { ConfigInfoModule } from './config-info/config.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { TopicModule } from './topic/topic.module';
     NotificationTemplateModule,
     AdCampaignModule,
     TopicModule,
+    ConfigInfoModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/config-info/config.controller.ts
+++ b/src/config-info/config.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get } from '@nestjs/common';
+import { PostType } from 'src/prisma/post-type';
+import { UserRole } from 'src/prisma/user-role';
+import { CrewStatus } from 'src/prisma/crew-status';
+import { PostVisibility } from 'src/prisma/post-visibility';
+
+@Controller('config')
+export class ConfigController {
+  @Get('post-types')
+  getPostTypes() {
+    return Object.values(PostType);
+  }
+
+  @Get('user-roles')
+  getUserRoles() {
+    return Object.values(UserRole);
+  }
+
+  @Get('crew-status')
+  getCrewStatus() {
+    return Object.values(CrewStatus);
+  }
+
+  @Get('post-visibility')
+  getPostVisibility() {
+    return Object.values(PostVisibility);
+  }
+}

--- a/src/config-info/config.module.ts
+++ b/src/config-info/config.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ConfigController } from './config.controller';
+
+@Module({
+  controllers: [ConfigController],
+})
+export class ConfigInfoModule {}

--- a/test/config.e2e-spec.ts
+++ b/test/config.e2e-spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('ConfigController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/config/post-types (GET)', async () => {
+    const res = await request(app.getHttpServer()).get('/config/post-types');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toContain('TALK');
+  });
+
+  it('/config/user-roles (GET)', async () => {
+    const res = await request(app.getHttpServer()).get('/config/user-roles');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toContain('USER');
+  });
+
+  it('/config/crew-status (GET)', async () => {
+    const res = await request(app.getHttpServer()).get('/config/crew-status');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toContain('ACTIVE');
+  });
+
+  it('/config/post-visibility (GET)', async () => {
+    const res = await request(app.getHttpServer()).get('/config/post-visibility');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toContain('PUBLIC');
+  });
+});


### PR DESCRIPTION
## Summary
- add controller and module for config data
- list config endpoints in README as implemented
- include e2e tests for new endpoints
- add TODO tasks for Column post permission and owner succession failure handling

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Environment variable not found)*

------
https://chatgpt.com/codex/tasks/task_e_686395b225c08320ba3f3c7026cbbf1c