### PR TITLE
Refactor getPosts return format

### DIFF
--- a/src/post/dto/post.dto.ts
+++ b/src/post/dto/post.dto.ts
@@ -1,0 +1,57 @@
+export type BrandMetaType = string;
+export type CrewMetaType = string;
+
+export interface UserDto {
+  id?: string;
+  email?: string;
+  username?: string;
+  nickname?: string;
+  bio?: string;
+  imageUrl?: string;
+  website?: string;
+  backgroundUrl?: string;
+  role?: string;
+  followerCount?: number;
+  followingCount?: number;
+  avatarUrl?: string;
+}
+
+export interface CrewDto {
+  id: string;
+  name: string;
+  avatarUrl?: string;
+  profileImage?: string;
+  coverImage?: string;
+  memberCount?: number;
+  description?: string;
+  tags?: string[];
+  links?: Array<{ title: string; url: string }>;
+  ownerId?: string;
+  followers?: any[];
+  members?: any[];
+  upcomingEvent?: { title: string; date: string };
+}
+
+export interface PostDto {
+  id: string | number;
+  title: string;
+  content?: string;
+  hashtags?: string[];
+  author?: UserDto;
+  createdAt?: string;
+  crewName?: string;
+  likes?: number;
+  comments?: number;
+  image?: string;
+  date?: string;
+  views?: number;
+  tags?: string[];
+  crew?: CrewDto[];
+  likeCount?: number;
+  commentCount?: number;
+  type?: string;
+  brandMetaType?: BrandMetaType;
+  crewMetaType?: CrewMetaType;
+  subtitle?: string;
+  imageUrl?: string;
+}

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -175,6 +175,7 @@ describe('PostService 서비스', () => {
           title: '크루 게시글',
           tags: [],
           author: {},
+          crew: { id: 'crew1', name: 'c1' },
           crewMentions: [],
           createdAt: new Date(),
         },
@@ -182,7 +183,7 @@ describe('PostService 서비스', () => {
       jest.spyOn(mockPrismaService.post, 'count').mockResolvedValue(1);
 
       const result = await service.getPosts(dto);
-      expect(result.posts[0].crewId).toBe('crew1');
+      expect(result.posts[0].crew?.[0].id).toBe('crew1');
     });
 
     it('tags, mention, query 등 다양한 조건으로 필터링이 가능해야 한다', async () => {
@@ -198,7 +199,7 @@ describe('PostService 서비스', () => {
           id: '3',
           title: '타이틀이름',
           tags: [{ name: '밥' }, { name: '고기' }],
-          crewMentions: [{ crewId: 'crew2' }],
+          crewMentions: [{ crew: { id: 'crew2', name: 'c2' } }],
           author: {},
           isDraft: false,
           createdAt: new Date(),
@@ -208,7 +209,7 @@ describe('PostService 서비스', () => {
 
       const result = await service.getPosts(dto);
       expect(result.posts[0].title).toContain('타이틀');
-      expect(result.posts[0].crewMentions[0].crewId).toBe('crew2');
+      expect(result.posts[0].crew?.[0].id).toBe('crew2');
     });
   });
 });


### PR DESCRIPTION
## Summary
- add `PostDto` along with `UserDto` and `CrewDto` definitions
- refactor `PostService.getPosts` to build response using `PostDto`
- adjust mocks in post service tests for new format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68772d5558e88320b4d3b8f49671c1e4