### PR TITLE
Refactor hashtag hot endpoint

### DIFF
--- a/src/hashtag/dto/hash-tag.dto.ts
+++ b/src/hashtag/dto/hash-tag.dto.ts
@@ -1,0 +1,4 @@
+export interface HashTag {
+  name: string;
+  postCount: number;
+}

--- a/src/hashtag/hashtag.service.spec.ts
+++ b/src/hashtag/hashtag.service.spec.ts
@@ -24,8 +24,10 @@ describe('HashtagService', () => {
     jest.clearAllMocks();
   });
 
-  it('calls prisma with default take', async () => {
-    mockPrisma.hashTag.findMany.mockResolvedValue([{ name: '#hot' }]);
+  it('calls prisma with default take and maps result', async () => {
+    mockPrisma.hashTag.findMany.mockResolvedValue([
+      { name: '#hot', _count: { postTags: 3 } },
+    ]);
 
     const result = await service.getHot();
 
@@ -34,7 +36,7 @@ describe('HashtagService', () => {
       take: 10,
       include: { _count: { select: { postTags: true } } },
     });
-    expect(result[0].name).toBe('#hot');
+    expect(result).toEqual([{ name: '#hot', postCount: 3 }]);
   });
 
   it('supports custom take value', async () => {

--- a/src/hashtag/hashtag.service.ts
+++ b/src/hashtag/hashtag.service.ts
@@ -1,16 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
+import { HashTag } from './dto/hash-tag.dto';
 
 @Injectable()
 export class HashtagService {
   constructor(private readonly prisma: PrismaService) {}
 
-  getHot(take = 10) {
+  async getHot(take = 10): Promise<HashTag[]> {
     const takeNum = Number(take);
-    return this.prisma.hashTag.findMany({
+    const tags = await this.prisma.hashTag.findMany({
       orderBy: { postTags: { _count: 'desc' } },
       take: takeNum,
       include: { _count: { select: { postTags: true } } },
     });
+    return tags.map((tag) => ({
+      name: tag.name,
+      postCount: tag._count.postTags,
+    }));
   }
 }


### PR DESCRIPTION
## Summary
- expose HashTag interface for hot hashtags
- return hashtags with post counts
- update service tests

## Testing
- `npm test`
- `npm run lint` *(fails: unsafe assignments in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68774fb880c48320bd4f76c578b18bc1