### PR TITLE
Add Crew summary DTO and endpoint

### DIFF
--- a/src/crew/crew.controller.ts
+++ b/src/crew/crew.controller.ts
@@ -20,36 +20,36 @@ import { CreatePostDto } from 'src/post/dto/create-post.dto';
 import { PostType } from 'src/prisma/post-type';
 import { CrewStatus } from 'src/prisma/crew-status';
 
-@Controller('crew')
+@Controller()
 export class CrewController {
   constructor(
     private readonly crewService: CrewService,
     private readonly postService: PostService,
   ) {}
 
-  @Get()
+  @Get('crews')
   list(@Query('sort') sort?: string) {
     return this.crewService.list(sort);
   }
 
   @UseGuards(JwtAuthGuard)
-  @Post()
+  @Post('crew')
   create(@Body() dto: CreateCrewDto, @Req() req: RequestWithUser) {
     return this.crewService.create(dto, req.user.id);
   }
 
-  @Get(':id')
+  @Get('crew/:id')
   findOne(@Param('id') id: string) {
     return this.crewService.findOne(id);
   }
 
-  @Get(':id/posts')
+  @Get('crew/:id/posts')
   getCrewPosts(@Param('id') id: string) {
     return this.postService.getPosts({ crewId: id });
   }
 
   @UseGuards(JwtAuthGuard)
-  @Post(':id/posts')
+  @Post('crew/:id/posts')
   createCrewPost(
     @Param('id') id: string,
     @Body() dto: CreatePostDto,
@@ -62,7 +62,7 @@ export class CrewController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Patch(':id')
+  @Patch('crew/:id')
   update(
     @Param('id') id: string,
     @Body() dto: UpdateCrewDto,
@@ -72,7 +72,7 @@ export class CrewController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Patch(':id/status')
+  @Patch('crew/:id/status')
   updateStatus(
     @Param('id') id: string,
     @Body('status') status: CrewStatus,
@@ -82,7 +82,7 @@ export class CrewController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Patch(':id/transfer-ownership')
+  @Patch('crew/:id/transfer-ownership')
   transferOwnership(
     @Param('id') id: string,
     @Body('userId') newOwnerId: string,
@@ -92,7 +92,7 @@ export class CrewController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Delete(':id')
+  @Delete('crew/:id')
   remove(@Param('id') id: string, @Req() req: RequestWithUser) {
     return this.crewService.delete(id, req.user.id);
   }

--- a/src/crew/crew.service.spec.ts
+++ b/src/crew/crew.service.spec.ts
@@ -145,9 +145,22 @@ describe('CrewService', () => {
 
     await service.list('popular');
 
-    expect(mockPrismaService.crew.findMany).toHaveBeenCalledWith({
-      orderBy: { members: { _count: 'desc' } },
-      include: { _count: { select: { members: true } } },
-    });
+    expect(mockPrismaService.crew.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { members: { _count: 'desc' } },
+        include: expect.objectContaining({
+          _count: { select: { members: true } },
+          crewTabs: {
+            where: { hashtag: { not: null } },
+            select: { hashtag: true },
+          },
+          events: expect.objectContaining({
+            orderBy: { date: 'asc' },
+            take: 1,
+            select: { title: true, date: true },
+          }),
+        }),
+      }),
+    );
   });
 });

--- a/src/crew/dto/crew-summary.dto.ts
+++ b/src/crew/dto/crew-summary.dto.ts
@@ -1,0 +1,8 @@
+export interface CrewSummaryDto {
+  id: string;
+  name: string;
+  coverImage?: string;
+  tags: string[];
+  memberCount: number;
+  upcomingEvent?: { title: string; date: string };
+}

--- a/test/crew.e2e-spec.ts
+++ b/test/crew.e2e-spec.ts
@@ -80,7 +80,10 @@ describe('CrewController (e2e)', () => {
         password: '1234',
       });
     const userId = signup.body.id as string;
-    await prisma.user.update({ where: { id: userId }, data: { status: 'ACTIVE' } });
+    await prisma.user.update({
+      where: { id: userId },
+      data: { status: 'ACTIVE' },
+    });
 
     const login = await request(app.getHttpServer())
       .post('/auth/login')
@@ -156,7 +159,7 @@ describe('CrewController (e2e)', () => {
     expect(res.status).toBe(200);
   });
 
-  it('/crew?sort=popular (GET)', async () => {
+  it('/crews?sort=popular (GET)', async () => {
     const server = app.getHttpServer();
 
     const s1 = await request(server)
@@ -197,7 +200,10 @@ describe('CrewController (e2e)', () => {
     const m1 = await request(server)
       .post('/auth/signup')
       .send({ email: 'mem1@test.com', username: 'mem1', password: '1234' });
-    await prisma.user.update({ where: { id: m1.body.id }, data: { status: 'ACTIVE' } });
+    await prisma.user.update({
+      where: { id: m1.body.id },
+      data: { status: 'ACTIVE' },
+    });
     const lm1 = await request(server)
       .post('/auth/login')
       .send({ email: 'mem1@test.com', password: '1234' });
@@ -208,7 +214,10 @@ describe('CrewController (e2e)', () => {
     const m2 = await request(server)
       .post('/auth/signup')
       .send({ email: 'mem2@test.com', username: 'mem2', password: '1234' });
-    await prisma.user.update({ where: { id: m2.body.id }, data: { status: 'ACTIVE' } });
+    await prisma.user.update({
+      where: { id: m2.body.id },
+      data: { status: 'ACTIVE' },
+    });
     const lm2 = await request(server)
       .post('/auth/login')
       .send({ email: 'mem2@test.com', password: '1234' });
@@ -216,10 +225,10 @@ describe('CrewController (e2e)', () => {
       .post(`/crew/${crew1Id}/join`)
       .set('Authorization', `Bearer ${lm2.body.accessToken}`);
 
-    const res = await request(server).get('/crew?sort=popular');
+    const res = await request(server).get('/crews?sort=popular');
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body[0].id).toBe(crew1Id);
-    expect(res.body[0]._count.members).toBe(2);
+    expect(res.body[0].memberCount).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- implement `CrewSummaryDto` to describe minimal crew data
- extend `CrewService.list` to return crew summaries
- expose list endpoint at `/crews`
- update e2e and unit tests for new response structure

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687752c850008320aee0f399a1fbaf62