### PR TITLE
Return normalized comment from update endpoint

### DIFF
--- a/src/comment/comment.controller.ts
+++ b/src/comment/comment.controller.ts
@@ -14,6 +14,7 @@ import { RequestWithUser } from 'src/common/types/request-with-user';
 import { CommentService } from './comment.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
+import { PostDetailCommentDto } from 'src/post/dto/post-detail-comment.dto';
 
 @Controller('comment')
 export class CommentController {
@@ -36,7 +37,7 @@ export class CommentController {
     @Param('id') id: string,
     @Body() dto: UpdateCommentDto,
     @Req() req: RequestWithUser,
-  ) {
+  ): Promise<PostDetailCommentDto> {
     return this.commentService.updateComment(id, dto, req.user.id);
   }
 

--- a/src/comment/comment.service.spec.ts
+++ b/src/comment/comment.service.spec.ts
@@ -48,7 +48,12 @@ describe('CommentService 서비스', () => {
       id: '1',
       authorId: 'u1',
     });
-    mockPrisma.comment.update.mockResolvedValue({ id: '1', content: 'new' });
+    mockPrisma.comment.update.mockResolvedValue({
+      id: '1',
+      content: 'new',
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      author: { id: 'u1', username: 'test' },
+    });
 
     const dto: UpdateCommentDto = { content: 'new' };
     const result = await service.updateComment('1', dto, 'u1');
@@ -56,8 +61,19 @@ describe('CommentService 서비스', () => {
     expect(mockPrisma.comment.update).toHaveBeenCalledWith({
       where: { id: '1' },
       data: dto,
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        author: { select: { id: true, username: true } },
+      },
     });
-    expect(result.content).toBe('new');
+    expect(result).toEqual({
+      id: '1',
+      content: 'new',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      author: { id: 'u1', username: 'test' },
+    });
   });
 
   it('작성자가 아닌 경우 수정 시 예외 발생', async () => {

--- a/src/comment/comment.service.ts
+++ b/src/comment/comment.service.ts
@@ -2,6 +2,7 @@ import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
+import { PostDetailCommentDto } from 'src/post/dto/post-detail-comment.dto';
 
 @Injectable()
 export class CommentService {
@@ -29,16 +30,30 @@ export class CommentService {
     });
   }
 
-  async updateComment(id: string, dto: UpdateCommentDto, userId: string) {
+  async updateComment(
+    id: string,
+    dto: UpdateCommentDto,
+    userId: string,
+  ): Promise<PostDetailCommentDto> {
     const comment = await this.prisma.comment.findUnique({ where: { id } });
     if (!comment || comment.authorId !== userId) {
       throw new HttpException('Comment not found', HttpStatus.NOT_FOUND);
     }
 
-    return this.prisma.comment.update({
+    const updated = await this.prisma.comment.update({
       where: { id },
       data: dto,
+      select: {
+        id: true,
+        content: true,
+        createdAt: true,
+        author: {
+          select: { id: true, username: true },
+        },
+      },
     });
+
+    return { ...updated, createdAt: updated.createdAt.toISOString() };
   }
 
   async deleteComment(id: string, userId: string) {


### PR DESCRIPTION
## Summary
- expose `PostDetailCommentDto` in comment update endpoint
- adjust comment service to return author and created date as ISO string
- update unit tests for new response shape

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68789dd36dbc8320965a9afc2dfd7466