### PR TITLE
Add user profile endpoint

### DIFF
--- a/src/post/dto/get-posts.dto.ts
+++ b/src/post/dto/get-posts.dto.ts
@@ -51,4 +51,9 @@ export class GetPostsDto {
   @IsOptional()
   @IsString()
   query?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  authorId?: string;
 }

--- a/src/post/post.service.spec.ts
+++ b/src/post/post.service.spec.ts
@@ -212,6 +212,26 @@ describe('PostService 서비스', () => {
       expect(result.posts[0].title).toContain('타이틀');
       expect(result.posts[0].crew?.[0].id).toBe('crew2');
     });
+
+    it('authorId로 필터링된 게시글만 반환해야 한다', async () => {
+      const dto = { take: '1', authorId: 'user1' } as any;
+      jest.spyOn(mockPrismaService.post, 'findMany').mockResolvedValue([
+        {
+          id: '4',
+          authorId: 'user1',
+          title: '사용자 글',
+          tags: [],
+          author: {},
+          crewMentions: [],
+          createdAt: new Date(),
+          isDraft: false,
+        },
+      ]);
+      jest.spyOn(mockPrismaService.post, 'count').mockResolvedValue(1);
+
+      const result = await service.getPosts(dto);
+      expect(result.posts[0].id).toBe('4');
+    });
   });
 
   describe('getPostComments', () => {

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -117,11 +117,21 @@ export class PostService {
       nextCursor: string | null;
     };
   }> {
-    const { take = '10', cursor, tags, crewId, mention, query, postType } = dto;
+    const {
+      take = '10',
+      cursor,
+      tags,
+      crewId,
+      mention,
+      query,
+      postType,
+      authorId,
+    } = dto;
     const takeNum = parseInt(take, 10);
 
     const where: Prisma.PostWhereInput = {
       isDraft: false,
+      ...(authorId && { authorId }),
       ...(postType && { type: postType }),
       ...(tags &&
         tags?.length > 0 && {

--- a/src/user/dto/profile.dto.ts
+++ b/src/user/dto/profile.dto.ts
@@ -1,0 +1,22 @@
+import { CrewDto, PostDto as PostBase } from 'src/post/dto/post.dto';
+
+export interface PageInfo {
+  hasNextPage: boolean;
+  nextCursor?: string;
+  totalCount?: number;
+}
+
+export interface PostDto {
+  pageInfo: PageInfo;
+  posts: PostBase[];
+}
+
+export interface ProfileDto {
+  id: string;
+  username: string;
+  bio: string;
+  imageUrl: string;
+  tags: string[];
+  posts: PostDto;
+  crews: CrewDto[];
+}

--- a/src/user/user.controller.spec.ts
+++ b/src/user/user.controller.spec.ts
@@ -5,7 +5,7 @@ import { UserStatus } from 'src/prisma/user-status';
 import { UserRole } from 'src/prisma/user-role';
 
 const mockUserService = {
-  getUserById: jest.fn(),
+  getProfileById: jest.fn(),
   updateUser: jest.fn(),
   updateStatus: jest.fn(),
   requestBrandRole: jest.fn(),
@@ -29,11 +29,11 @@ describe('UserController', () => {
   });
 
   it('getUser calls service with id', async () => {
-    mockUserService.getUserById.mockResolvedValue({ id: '1' });
+    mockUserService.getProfileById.mockResolvedValue({ id: '1' });
 
     const result = await userController.getUser('1');
 
-    expect(mockUserService.getUserById).toHaveBeenCalledWith('1');
+    expect(mockUserService.getProfileById).toHaveBeenCalledWith('1');
     expect(result).toEqual({ id: '1' });
   });
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -23,7 +23,7 @@ export class UserController {
 
   @Get(':id')
   getUser(@Param('id') id: string) {
-    return this.userService.getUserById(id);
+    return this.userService.getProfileById(id);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -3,8 +3,10 @@ import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { FollowService } from './follow.service';
 import { FollowController } from './follow.controller';
+import { PostModule } from 'src/post/post.module';
 
 @Module({
+  imports: [PostModule],
   providers: [UserService, FollowService],
   controllers: [UserController, FollowController],
 })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -3,10 +3,15 @@ import { PrismaService } from '../prisma/prisma.service';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UserStatus } from 'src/prisma/user-status';
 import { UserRole } from 'src/prisma/user-role';
+import { PostService } from 'src/post/post.service';
+import { ProfileDto } from './dto/profile.dto';
 
 @Injectable()
 export class UserService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly postService: PostService,
+  ) {}
 
   getUserById(userId: string) {
     return this.prisma.user.findUnique({
@@ -20,6 +25,88 @@ export class UserService {
         status: true,
       },
     });
+  }
+
+  async getProfileById(userId: string): Promise<ProfileDto | null> {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        username: true,
+        avatarUrl: true,
+        bio: true,
+        crewMemberships: {
+          include: {
+            crew: {
+              include: {
+                owner: {
+                  select: { id: true, username: true, avatarUrl: true },
+                },
+                _count: { select: { members: true } },
+                crewTabs: {
+                  where: { hashtag: { not: null } },
+                  select: { hashtag: true },
+                },
+                events: {
+                  where: { date: { gte: new Date() } },
+                  orderBy: { date: 'asc' },
+                  take: 1,
+                  select: { title: true, date: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!user) return null;
+
+    const postResult = await this.postService.getPosts({
+      take: '10',
+      authorId: userId,
+    });
+    const posts = {
+      posts: postResult.posts,
+      pageInfo: {
+        ...postResult.pageInfo,
+        nextCursor: postResult.pageInfo.nextCursor ?? undefined,
+      },
+    };
+
+    const crews = user.crewMemberships.map((m) => ({
+      id: m.crew.id,
+      name: m.crew.name,
+      avatarUrl: m.crew.avatarUrl ?? undefined,
+      profileImage: undefined,
+      coverImage: undefined,
+      memberCount: m.crew._count.members,
+      description: m.crew.description ?? undefined,
+      tags: m.crew.crewTabs.map((t) => t.hashtag as string).filter(Boolean),
+      links: (m.crew.externalLinks as any) ?? undefined,
+      owner: {
+        id: m.crew.owner.id,
+        username: m.crew.owner.username,
+        avatarUrl: m.crew.owner.avatarUrl ?? undefined,
+      },
+      members: undefined,
+      upcomingEvent: m.crew.events[0]
+        ? {
+            title: m.crew.events[0].title,
+            date: m.crew.events[0].date.toISOString(),
+          }
+        : undefined,
+    }));
+
+    return {
+      id: user.id,
+      username: user.username,
+      bio: user.bio ?? '',
+      imageUrl: user.avatarUrl ?? '',
+      tags: [],
+      posts,
+      crews,
+    };
   }
 
   async updateUser(userId: string, updateUserDto: UpdateUserDto) {


### PR DESCRIPTION
## Summary
- support filtering posts by author
- expose profile DTO schema
- return profile for `GET /users/:id`
- wire PostModule into UserModule
- add unit tests for new functionality

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6878aa80ae44832085ec4be168703364